### PR TITLE
feat: montu remove email validation for rescheduledby

### DIFF
--- a/apps/api/v1/lib/validations/booking.ts
+++ b/apps/api/v1/lib/validations/booking.ts
@@ -35,8 +35,16 @@ const schemaBookingEditParams = z
     title: z.string().optional(),
     startTime: iso8601.optional(),
     endTime: iso8601.optional(),
-    cancelledBy: z.string().email({ message: "Invalid Email" }).optional(),
-    rescheduledBy: z.string().email({ message: "Invalid Email" }).optional(),
+    cancelledBy: z
+      .string()
+      .regex(/^[A-Za-z0-9+/=]*$/)
+      .max(200)
+      .optional(), // Montu - remove email validation for base64 usage
+    rescheduledBy: z
+      .string()
+      .regex(/^[A-Za-z0-9+/=]*$/)
+      .max(200)
+      .optional(), // Montu - remove email validation for base64 usage
     // Not supporting responses in edit as that might require re-triggering emails
     // responses
   })

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -236,7 +236,11 @@ export const bookingCreateBodySchema = z.object({
   eventTypeSlug: z.string().optional(),
   rescheduleUid: z.string().optional(),
   recurringEventId: z.string().optional(),
-  rescheduledBy: z.string().email({ message: "Invalid email" }).optional(),
+  rescheduledBy: z
+    .string()
+    .regex(/^[A-Za-z0-9+/=]*$/)
+    .max(200)
+    .optional(), // Montu - remove email validation for base64 usage
   start: z.string(),
   timeZone: z.string().refine((value: string) => isSupportedTimeZone(value), { message: "Invalid timezone" }),
   user: z.union([z.string(), z.array(z.string())]).optional(),
@@ -320,7 +324,11 @@ export const schemaBookingCancelParams = z.object({
   allRemainingBookings: z.boolean().optional(),
   cancellationReason: z.string().optional(),
   seatReferenceUid: z.string().optional(),
-  cancelledBy: z.string().email({ message: "Invalid email" }).optional(),
+  cancelledBy: z
+    .string()
+    .regex(/^[A-Za-z0-9+/=]*$/)
+    .max(200)
+    .optional(), // Montu - remove email validation for base64 usage
 });
 
 export const vitalSettingsUpdateSchema = z.object({


### PR DESCRIPTION
## What does this PR do?

remove email validation on `rescheduledBy` and `cancelledBy` and replace with base64 validation. 

merge into branch `fix/fork-for-v4.4.9`  which is targeted by montu calcom deployment: https://github.com/MontuGroup/montu-cal.com/blob/main/.gitmodules