### PR TITLE
fix: allow editing default schedule from team availability screen

### DIFF
--- a/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
+++ b/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
@@ -234,10 +234,9 @@ export function AvailabilitySliderTable(props: { userTimeFormat: number | null; 
             table={table}
             tableContainerRef={tableContainerRef}
             onRowMouseclick={(row) => {
-              if (props.isOrg) {
-                setEditSheetOpen(true);
-                setSelectedUser(row.original);
-              }
+              // Calcom not considering self hosters again.  They removed the ability to edit schedules from this page.  This hopefully forced clinic to start using PMS for updating nurse schedules, maybe we leave it disabled?
+              setEditSheetOpen(true);
+              setSelectedUser(row.original);
             }}
             isPending={isPending}
             onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}>


### PR DESCRIPTION
## What does this PR do?
remove broken isOrg logic that prevents editing schedules from the team availability screen.

https://github.com/user-attachments/assets/6956f61a-b02c-412d-8e9b-a39d69d30dba

Notice this doesn't work in staging or production at the current moment. 


## Mandatory Tasks (DO NOT REMOVE)
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
