### PR TITLE
feat: add defaults to api v1 calls for doctor onboarding

### DIFF
--- a/apps/api/v1/lib/validations/event-type.ts
+++ b/apps/api/v1/lib/validations/event-type.ts
@@ -87,6 +87,7 @@ const schemaEventTypeCreateParams = z
     bookingFields: eventTypeBookingFields.optional(),
     scheduleId: z.number().optional(),
     parentId: z.number().optional(),
+    allowReschedulingPastBookings: z.boolean().optional().default(true), // Montu - enable this setting by default on new Doctor Event Types
   })
   .strict();
 

--- a/apps/api/v1/lib/validations/user.ts
+++ b/apps/api/v1/lib/validations/user.ts
@@ -134,6 +134,7 @@ const schemaUserCreateParams = z.object({
   locale: z.nativeEnum(locales).optional(),
   createdDate: iso8601.optional(),
   avatar: z.string().refine(isValidBase64Image).optional(),
+  completedOnboarding: z.boolean().optional().default(true), // Montu - we don't need user to go through onboarding, adds complexity when clinic use impersonation feature
 });
 
 // @note: These are the values that are editable via PATCH method on the user Model,


### PR DESCRIPTION
## What does this PR do?
adds defaults to api v1 calls for doctor creation and event type creation
- default `allowReschedulingPastBookings` to true on all new event types
- default `completedOnboarding` to true on all new users


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).

## How should this be tested?
when running calcom and pms locally
- creating a doctor/nurse should automatically set their `completedOnboarding`  to TRUE
- event types created for the doctor should have `allowReschedulingPastBookings` set to TRUE
