### PR TITLE
feat: include scheduledId on event type hosts response

### DIFF
--- a/apps/api/v1/lib/validations/event-type.ts
+++ b/apps/api/v1/lib/validations/event-type.ts
@@ -22,6 +22,7 @@ const recurringEventInputSchema = z.object({
 const hostSchema = _HostModel.pick({
   isFixed: true,
   userId: true,
+  scheduleId: true,
 });
 
 export const childrenSchema = z.object({

--- a/apps/api/v1/pages/api/event-types/[id]/_get.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_get.ts
@@ -53,7 +53,7 @@ export async function getHandler(req: NextApiRequest) {
       customInputs: true,
       hashedLink: { select: { link: true } },
       team: { select: { slug: true } },
-      hosts: { select: { userId: true, isFixed: true } },
+      hosts: { select: { userId: true, isFixed: true, scheduleId: true } },
       owner: { select: { username: true, id: true } },
       children: { select: { id: true, userId: true } },
     },


### PR DESCRIPTION
## What does this PR do?
Add scheduleID to calcom API response for GET event type.
- this is needed in order to manage round robin hosts and custom schedules in PMS


JIRA: https://montugroup.atlassian.net/browse/LGA-483

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
