### PR TITLE
fix: pin jest-date-mock

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -90,7 +90,7 @@
     "@types/passport-jwt": "^3.0.13",
     "@types/supertest": "^2.0.12",
     "jest": "^29.7.0",
-    "jest-date-mock": "^1.0.10",
+    "jest-date-mock": "1.0.10",
     "prettier": "^2.8.6",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3540,7 +3540,7 @@ __metadata:
     helmet: ^7.1.0
     ioredis: ^5.3.2
     jest: ^29.7.0
-    jest-date-mock: ^1.0.10
+    jest-date-mock: 1.0.10
     jsforce: ^1.11.0
     lodash: ^4.17.21
     luxon: ^3.4.4
@@ -31055,7 +31055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-date-mock@npm:^1.0.10":
+"jest-date-mock@npm:1.0.10":
   version: 1.0.10
   resolution: "jest-date-mock@npm:1.0.10"
   checksum: 3bbdbc798e7827787392d66083d5ebbf050741003ac7732a5c84f33accb60f38a25670312745400052000d6b4df8377909b7afc700df6b0e09bdb78b89eb18cc


### PR DESCRIPTION
## What does this PR do?
pin jest-date-mock version to avoid compromised package. 

slack: https://montuhq.slack.com/archives/C05C97TKCHJ/p1779168836859849 

